### PR TITLE
fix: choose optimal arbit based on percent (instead of usd)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -26,7 +26,7 @@ const App = async () => {
 
   const topProfitableResult = allArbitResults.reduce(
     (topCandidate, arbitResult) =>
-      arbitResult.profit.usd > topCandidate.profit.usd
+      arbitResult.profit.percent > topCandidate.profit.percent
         ? arbitResult
         : topCandidate,
     /**


### PR DESCRIPTION
Closes #73 